### PR TITLE
Unfuck bungeecord.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,5 +2,4 @@ name: Inabate
 version: ${version}
 main: com.inabate.bukkit.BukkitCDN
 depend: [ProtocolLib]
-authors: [suedadam, Sponges]
 description: Inabate


### PR DESCRIPTION
BungeeCord doesn't seem to care about the authors property, so get rid of it.
